### PR TITLE
Add popup text for damageUp aura field.

### DIFF
--- a/src/summon.js
+++ b/src/summon.js
@@ -25,6 +25,7 @@ var raceTypes = GlobalConst.raceTypes;
 var sexTypes = GlobalConst.sexTypes;
 var filterElementTypes = GlobalConst.filterElementTypes;
 var enemyDefenseType = GlobalConst.enemyDefenseType;
+var TextWithTooltip = GlobalConst.TextWithTooltip;
 
 var SummonList = CreateClass({
     getInitialState: function () {
@@ -412,6 +413,7 @@ var Summon = CreateClass({
                                          onChange={this.handleEvent.bind(this, "ougiDamage")}/>
                         </td>
                     </tr>
+                    <TextWithTooltip tooltip={intl.translate("セラフィック加護説明", locale)} id={"tooltip-tenshi-aura-detail"}>
                     <tr>
                         <th className="bg-primary">{intl.translate("セラフィック加護", locale)}</th>
                         <td>
@@ -419,6 +421,7 @@ var Summon = CreateClass({
                                          onChange={this.handleEvent.bind(this, "tenshiDamageUP")}/>
                         </td>
                     </tr>
+                    </TextWithTooltip>
                     </tbody>
                 </table>
 


### PR DESCRIPTION
セラフィック加護説明をポップアップ表示するパッチです。

セラフィック加護説明の id={"tooltip-tenshi-aura-detail"} の部分、
恐らく適当な文字列で良いはずなので、仮でつけたのですが、
意味的に天使加護だと天司石の加護（上限upの方）と混同しやすそうなので注意。

「セラフィック加護」の名称を変える時は、適宜このidも変えてください。
（機能への影響はありません）