### PR TITLE
Add unit test for calcOugiFixedDamage

### DIFF
--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -254,6 +254,7 @@ module.exports.calcOugiDamage = function (summedAttack, totalSkillCoeff, critica
 function calcOugiFixedDamage(key) {
     return (key == "Djeeta") ? 3000 : 2000;
 }
+module.exports.calcOugiFixedDamage = calcOugiFixedDamage;
 
 module.exports.calcChainBurst = function (ougiDamage, chainNumber, typeBonus, enemyResistance, chainDamageUP, chainDamageLimitUP) {
     if (chainNumber <= 1) return 0.0;

--- a/src/global_logic.test.js
+++ b/src/global_logic.test.js
@@ -1,4 +1,10 @@
-var {getTypeBonus, calcDefenseDebuff, calcLBHaisuiValue, isDarkOpus} = require('./global_logic.js');
+const {
+    getTypeBonus,
+    calcDefenseDebuff,
+    calcLBHaisuiValue,
+    isDarkOpus,
+    calcOugiFixedDamage
+} = require('./global_logic.js');
 
 describe('#getTypeBonus', () => {
     test('when self element and enemy element is not set, type bonus is 1', () => {
@@ -107,6 +113,7 @@ describe('#calcLBHaisui', () => {
     });
 });
 
+
 describe('#isDarkOpus', () => {
     test('Checking Dark Opus arm', () => {
         expect(isDarkOpus({"name": "絶対否定の剣"})).toBeTruthy();
@@ -136,4 +143,18 @@ describe('#isDarkOpus', () => {
         expect(isDarkOpus({"name": "Staff of epudiation"})).toBeFalsy();
     });
 
+});
+
+describe('#calcOugiFixedDamage', () => {
+    test('ougi fixed damage for Djeeta is 3000', () => {
+        expect(calcOugiFixedDamage("Djeeta")).toBe(3000);
+    });
+
+    test('ougi fixed damage for others is 2000', () => {
+        expect(calcOugiFixedDamage("test")).toBe(2000);
+    });
+
+    test('ougi fixed damage for empty key is 2000', () => {
+        expect(calcOugiFixedDamage("")).toBe(2000);
+    });
 });


### PR DESCRIPTION
Add unit test for MotocalDevelopers/motocal/pull/260

 - global_logic.js
    - Export the test target function
      - unlike other, module.export.calcOugiFixedDamage = function
      - production code does not need to export this function.
        we can comment out the export in build time (currently not)
  - global_logic.test.js
    - clean up import(require) line. it's became too long
    - Change `var` to `const`, they are not override, safe to be `const`
      (No side effects by this change)
    - Add spec for calcOugiFixedDamage

----

- テストは現状のケースではあまり役に立ってませんが、将来の為のテスト整備。
- var -> const 読み込んだ関数は上書きされることはない為、変更による他への影響なし。
- require する行が長くなったので、行を別ける。(後々追加するときにdiff が見やすくなります)
- module.exports.calcOugiFixedDamage = calcOugiFixedDamage;
  - ここだけ他と export の方法が異なりますが、
    - 通常は、calcOugiFixedDamage は他のファイルからは必要とされず
      テスト時のみ、テストファイルから使うため export が必要な為。
    - 分離することで、テスト時のみ export と後々対応しやすくなります。
    - module.exports.calcOugiFixedDamage = function ... に変更すると
      コード中の呼び出し方法も変更が必要。

