### PR TITLE
Change DA/TA fields for support

### DIFF
--- a/src/global_const.js
+++ b/src/global_const.js
@@ -1907,15 +1907,15 @@ var supportAbilities = {
     },
     "data_up_wind_10_5": {
         "name": "全体風DA率10%UP&TA率5%UP(コッコロ)",
-        "type": "dataBuff_wind",
-        "range": "all",
-        "value": 0.00
+        "type": "DATASupport",
+        "range": "wind",
+        "value": [0.10, 0.05]
     },
     "data_up_water_10_5": {
         "name": "全体水DA率10%UP&TA率5%UP(水着ディアンサ)",
-        "type": "dataBuff_water",
-        "range": "all",
-        "value": 0.00
+        "type": "DATASupport",
+        "range": "water",
+        "value": [0.10, 0.05]
     },
     "da_up_fist_10": {
         "name": "格闘キャラDA率10%UP(ガンダゴウザ)",

--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -2592,32 +2592,21 @@ module.exports.treatSupportAbility = function (totals, chara) {
                     continue;
                 case "normalBuff_depends_member":
                     continue;
-                case "dataBuff_wind":
+                case "DATASupport":
+                    let [daRate, taRate] = support.value;
                     if (totals[key].isConsideredInAverage) {
-                        for (var key2 in totals) {
-                            if (totals[key2]["element"] === "wind") {
-                                totals[key2]["DASupport"] += 0.10;
-                                totals[key2]["TASupport"] += 0.05;
+                        for (let key2 in totals) {
+                            if (totals[key2]["element"] === support.range
+                              || support.range === "all"
+                              || (support.range === "own" && key === key2)) {
+                                totals[key2]["DASupport"] += daRate;
+                                totals[key2]["TASupport"] += taRate;
                             }
                         }
                     } else {
                         // Calculate yourself only if you do not put it in the average
-                        totals[key]["DASupport"] += 0.10;
-                        totals[key]["TASupport"] += 0.05;
-                    }
-                    continue;
-                case "dataBuff_water":
-                    if (totals[key].isConsideredInAverage) {
-                        for (var key2 in totals) {
-                            if (totals[key2]["element"] === "water") {
-                                totals[key2]["DABuff"] += 0.10;
-                                totals[key2]["TABuff"] += 0.05;
-                            }
-                        }
-                    } else {
-                        // Calculate yourself only if you do not put it in the average
-                        totals[key]["DABuff"] += 0.10;
-                        totals[key]["TABuff"] += 0.05;
+                        totals[key]["DASupport"] += daRate;
+                        totals[key]["TASupport"] += taRate;
                     }
                     continue;
                 case "daBuff_fist":


### PR DESCRIPTION
PR for MotocalDevelopers/motocal/pull/257

MotocalDevelopers/motocal/pull/246 changed field name for support ability

- Implement "DATASupport" support type
  - range: "all", "own", or elements ("water", "wind", ...)
    - currently only "water", "wind" support are implemented.
      other range are unused
    - this range does not take favorite weapon type.
  - value: [daRate, taRate]
  - `data_up_water_10_5` and `data_up_wind_10_5`
    now use same support type with different parameter.

This change will reduce the management costs of the clone code.