### PR TITLE
Change deep copy of generate limit values

### DIFF
--- a/src/global_const.js
+++ b/src/global_const.js
@@ -80,6 +80,11 @@ module.exports._ua = (function (u) {
     }
 })(window.navigator.userAgent.toLowerCase());
 
+module.exports.BASE_LIMIT_VALUES = {
+    normalDamage: [[600000, 0.01], [500000, 0.05], [400000, 0.60], [300000, 0.80]],
+    ougiDamage: [[2500000, 0.01], [1800000, 0.05], [1700000, 0.30], [1500000, 0.60]],
+};
+
 const UNLIMIT_VALUE = 99999;
 module.exports.LIMIT = {
     normalDA: 50,

--- a/src/global_logic.test.js
+++ b/src/global_logic.test.js
@@ -5,7 +5,8 @@ const {
     isDarkOpus,
     calcOugiFixedDamage,
     sum,
-    filterCombinations
+    filterCombinations,
+    _initLimitValues,
 } = require('./global_logic.js');
 
 describe('#getTypeBonus', () => {
@@ -189,5 +190,36 @@ describe('#filterCombinations', () => {
     test('Filtering lower size combinations', () => {
         expect(filterCombinations(testArray1, 2, true)).toStrictEqual(result1);
         expect(filterCombinations(testArray2, 7, true)).toStrictEqual(result2);
+    });
+});
+
+describe('#_initLimitValues', () => {
+    // using "let" here for tests
+    let testLimitValues = [];
+
+    beforeAll(() => {
+        testLimitValues = [[3000, 0.1], [2000, 0.5], [1000, 0.8]];
+    });
+
+    test('generate new limit values', () => {
+        expect(_initLimitValues(2, testLimitValues)).toStrictEqual([[6000, 0.1], [4000, 0.5], [2000, 0.8]]);
+        expect(_initLimitValues(1, testLimitValues)).toStrictEqual(testLimitValues); // Ok, nothing changed
+        expect(_initLimitValues(1, testLimitValues)).not.toBe(testLimitValues); // No, not same instance
+    });
+
+    test('does not have side effect to the source array', () => {
+        const copyValues = testLimitValues.slice(); // note: not deep copy
+        const deepCopyValues = testLimitValues.map(value => value.slice());
+        const limitValues = _initLimitValues(1.0, testLimitValues);
+
+        testLimitValues[0][0] = null; // for side effect test
+
+        expect(limitValues).not.toStrictEqual(testLimitValues);
+        expect(limitValues).toStrictEqual([[3000, 0.1], [2000, 0.5], [1000, 0.8]]);
+
+        // copyValues has side effect.
+        expect(copyValues).toStrictEqual(testLimitValues);
+        // deepCopyValues has no side effect.
+        expect(deepCopyValues).not.toStrictEqual(testLimitValues);
     });
 });


### PR DESCRIPTION
PR for MotocalDevelopers/motocal/pull/312

- Improve the deep copy implementation
  - Problem:
  JSON parse/stringify approach had made intermediate string data.
  The code has less intention that JSON just for deep copy.
  - Solution:
  This patch provideis the function for generate values with
  copied instance.
- Move base limit values to global_const.js
- ES2015, descructuring assignment with for-of loop.
  it's just make the code shorter.

要約:
deep copy の為に JSON文字列にシリアライズ/デシリアライズしているコードの改良

PRのトピック自体は未だ把握しておらず、コードのみに対するPRです。
確認方法がわからず、計算結果への影響まではチェックは出来てません。

----

- why separate function define and exports, other functions do together
  - it's a private function,
    we can make private function export only for test in future. (not now)
  - 関数の定義とエクスポートを別けたのは、プライベートな関数なので
    プロダクションコードでは exports 不要になるのを対応しやすくするため。
    (現在は未対応。テストの為にエクスポートしています)
- why not + 1.0 inside function
  - `initLimitValues(2, [[1000,1.0], [2000,2.0]]) => [[2000,1.0], [4000,2.0]])` 
    make it easy to understand the code reading.

1.0 を関数内で加算すると、+1.0 を4か所のコードの重複は避けられますが、
実行時に行われる加算処理の回数自体は減りません。

末端で加算するよりも、可能な限り元の値に加算した方が
各所で倍率の加算に +1 するようなコードが各所に散らばるのを避けられます。
但し、広範囲にわたってのテストが必要となる為、ここの最適化は見送ります。

